### PR TITLE
Add pre/post renewal hooks scripts

### DIFF
--- a/hetnet/neo4j/deployment/install_ssl.sh
+++ b/hetnet/neo4j/deployment/install_ssl.sh
@@ -25,7 +25,8 @@ sudo certbot certonly \
 # Create "sync-neo4j-ssl.sh" dynamically and run it:
 cat > ./sync-neo4j-ssl.sh << EOF
 #!/bin/bash
-# Certbot deploy-renewal-hook script that synchronizes SSL certificates for neo4j
+# Certbot deploy-renewal-hook script, which synchronizes SSL certificates for neo4j.
+# This script will be executed ONLY WHEN certificate is renrewed successfully.
 
 # Use 'cp --dereference' to emphasize that we are copying the actual files.
 cp --dereference --force /etc/letsencrypt/live/$SSL_DOMAIN/fullchain.pem /home/ubuntu/ssl/neo4j.cert

--- a/hetnet/neo4j/deployment/install_ssl.sh
+++ b/hetnet/neo4j/deployment/install_ssl.sh
@@ -35,12 +35,14 @@ EOF
 mkdir -p /home/ubuntu/ssl/
 chmod +x ./sync-neo4j-ssl.sh
 sudo ./sync-neo4j-ssl.sh
+
+# If hetionet-container is running now, restart it to make the new certificates effective.
 if [ -n $(docker ps --quiet --filter name=hetionet-container) ]; then
     echo -n "Restarting "
     docker restart hetionet-container
 fi
 
-# Add renewal-hooks, see:
+# Add renewal-hooks scripts, see:
 # https://certbot.eff.org/docs/using.html#renewing-certificates
 sudo cp --force ./stop-neo4j.sh /etc/letsencrypt/renewal-hooks/pre/
 sudo cp --force ./sync-neo4j-ssl.sh /etc/letsencrypt/renewal-hooks/deploy/

--- a/hetnet/neo4j/deployment/install_ssl.sh
+++ b/hetnet/neo4j/deployment/install_ssl.sh
@@ -26,7 +26,7 @@ sudo certbot certonly \
 cat > ./sync-neo4j-ssl.sh << EOF
 #!/bin/bash
 # Certbot deploy-renewal-hook script, which synchronizes SSL certificates for neo4j.
-# This script will be executed ONLY WHEN certificate is renrewed successfully.
+# This script will be executed ONLY WHEN certificate is renewed successfully.
 
 # Use 'cp --dereference' to emphasize that we are copying the actual files.
 cp --dereference --force /etc/letsencrypt/live/$SSL_DOMAIN/fullchain.pem /home/ubuntu/ssl/neo4j.cert

--- a/hetnet/neo4j/deployment/start-neo4j.sh
+++ b/hetnet/neo4j/deployment/start-neo4j.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Certbot post-renewal-hook script, which starts neo4j docker container.
+
+if [ -z $(docker ps --quiet --filter name=hetionet-container) ]; then
+    docker start hetionet-container
+fi

--- a/hetnet/neo4j/deployment/stop-neo4j.sh
+++ b/hetnet/neo4j/deployment/stop-neo4j.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Certbot pre-renewal-hook script, which stops neo4j docker container.
+
+if [ -n $(docker ps --quiet --filter name=hetionet-container) ]; then
+    docker stop hetionet-container
+fi


### PR DESCRIPTION
This PR adds `pre` and `post` renewal scripts so that the SSL certificate can be renewed successfully. The `pre` script stops neo4j docker container before renewal process (otherwise port 80 would be taken by the docker container and the renewal would fail); and `post` scripts starts the docker container.


